### PR TITLE
Publish apply-setters image to ghcr

### DIFF
--- a/functions/go/Makefile
+++ b/functions/go/Makefile
@@ -45,7 +45,8 @@ FUNCTIONS := \
 	upsert-resource
 
 FUNCTION_KO := \
-	set-name-prefix
+	set-name-prefix \
+	apply-setters
 
 # Targets for running all function tests
 FUNCTION_TESTS := $(patsubst %,%-TEST,$(FUNCTIONS))

--- a/functions/go/apply-setters/Makefile
+++ b/functions/go/apply-setters/Makefile
@@ -1,0 +1,12 @@
+# GCP project to use for development
+GOBIN := $(shell go env GOPATH)/bin
+
+export GCP_PROJECT_ID ?= $(shell gcloud config get-value project)
+export IMAGE_REPO ?= gcr.io/$(GCP_PROJECT_ID)
+export IMAGE_TAG ?= latest
+
+build:
+	KO_DOCKER_REPO=ko.local go run github.com/google/ko@v0.18.0 build -B --tags=${IMAGE_TAG} .
+
+push:
+	KO_DOCKER_REPO=${IMAGE_REPO} go run github.com/google/ko@v0.18.0 build -B --tags=${IMAGE_TAG} .

--- a/functions/go/apply-setters/krm-fn-metadata.yaml
+++ b/functions/go/apply-setters/krm-fn-metadata.yaml
@@ -1,0 +1,10 @@
+image: ghcr.io/kptdev/krm-functions-catalog/apply-setters
+description: Update the field values parameterized by setters.
+tags:
+  - mutator
+sourceURL: https://github.com/kptdev/krm-functions-catalog/tree/master/functions/go/apply-setters
+examplePackageURLs:
+  - https://github.com/kptdev/krm-functions-catalog/tree/master/examples/apply-setters-simple
+emails:
+  - kpt-team@google.com
+license: Apache-2.0


### PR DESCRIPTION
Begin the process of migrating the krm fn images to ghcr.
Following the same pattern as - https://github.com/kptdev/krm-functions-catalog/tree/master/functions/go/set-name-prefix