### PR TITLE
Add release tag gh action

### DIFF
--- a/.github/actions/extract-tag-info/action.yaml
+++ b/.github/actions/extract-tag-info/action.yaml
@@ -1,0 +1,38 @@
+name: "Extract Semver and Image Name from Tag"
+description: "Extracts semantic version and image name from a Git tag"
+runs:
+  using: "composite"
+  steps:
+    - name: Extract semver and image name
+      id: extract  # <--- must set id to reference outputs
+      shell: bash
+      run: |
+        echo "Extracting tag info from ${GITHUB_REF}"
+        REF="${GITHUB_REF}"
+        TAG="${REF#refs/tags/}"           # remove 'refs/tags/' prefix
+        VERSION="${TAG##*/}"              # get last part after last slash
+
+        # Remove 'functions/' or 'contrib/functions/' prefix
+        PATH_WITHOUT_PREFIX="${TAG#functions/}"
+        PATH_WITHOUT_PREFIX="${PATH_WITHOUT_PREFIX#contrib/functions/}"
+
+        # Remove 'go/' prefix if present
+        IMAGE_NAME="${PATH_WITHOUT_PREFIX#go/}"
+        IMAGE_NAME="${IMAGE_NAME%/*}"     # remove version at end
+
+        # Validate semver with optional pre-release and build metadata
+        if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "image_name=$IMAGE_NAME" >> $GITHUB_OUTPUT
+        else
+          echo "Error: Tag '$VERSION' is not a valid semver" >&2
+          exit 1
+        fi
+
+outputs:
+  version:
+    description: "The extracted semantic version from the tag"
+    value: ${{ steps.extract.outputs.version }}  # reference step id
+  image_name:
+    description: "The extracted image name (without functions/, contrib/functions/, or go/ prefixes)"
+    value: ${{ steps.extract.outputs.image_name }}  # reference step id

--- a/.github/workflows/after-push-to-branch.yaml
+++ b/.github/workflows/after-push-to-branch.yaml
@@ -1,6 +1,7 @@
 # Copyright 2022 Google LLC
 # Modifications Copyright (C) 2025 OpenInfra Foundation Europe.
 #
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -13,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Build and push latest curated images
+name: Build and push latest dev images
 on:
   push:
     branches:
@@ -25,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
+      contents: read
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
@@ -43,6 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
+      contents: read
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5

--- a/.github/workflows/after-tag-with-version.yaml
+++ b/.github/workflows/after-tag-with-version.yaml
@@ -13,25 +13,62 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Run the CD script after tags that look like versions
+name: Build and push tagged image
+
 on:
   push:
     tags:
-    - "**/v[0-9]+.*"
+      - "functions/*/*/v*"
+      - "contrib/functions/*/*/v*"
 
 jobs:
-  build:
-    name: after-tag-with-version
+  build-push-release:
     runs-on: ubuntu-latest
     permissions:
       packages: write
+      contents: read
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
-      with:
-        go-version: '1.24.3'
-    - run: go version
-    - name: dev/cd/after-tag-push
-      run: GIT_REF=${GITHUB_REF} IMAGE_REPO=ghcr.io/${{ github.repository }} dev/cd/after-tag-with-version
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.3'
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Extract semver and image name
+        id: extract
+        uses: ./.github/actions/extract-tag-info
+
+      - name: Show outputs
+        run: |
+          echo "Version = ${{ steps.extract.outputs.version }}"
+          echo "Image name = ${{ steps.extract.outputs.image_name }}"
+
+      - name: Determine release type and push image
+        run: |
+          VERSION="${{ steps.extract.outputs.version }}"
+          IMAGE_NAME="${{ steps.extract.outputs.image_name }}"
+
+          if [[ "${GITHUB_REF#refs/tags/}" == functions/* ]]; then
+            echo "Detected curated functions release"
+            cd functions/go
+            make func-push TAG=$VERSION CURRENT_FUNCTION=$IMAGE_NAME DEFAULT_CR=ghcr.io/${GITHUB_REPOSITORY}
+          elif [[ "${GITHUB_REF#refs/tags/}" == contrib/functions/* ]]; then
+            echo "Detected contrib functions release"
+            cd contrib/functions/go
+            make func-push TAG=$VERSION CURRENT_FUNCTION=$IMAGE_NAME DEFAULT_CR=ghcr.io/${GITHUB_REPOSITORY}/krm-fn-contrib
+          else
+            echo "Tag does not match any known type, skipping."
+            exit 0
+          fi

--- a/contrib/functions/go/Makefile
+++ b/contrib/functions/go/Makefile
@@ -131,8 +131,14 @@ func-build: func-verify
 	../../../scripts/go-function-release.sh build contrib
 
 func-push:
-	@echo Pushing image $(CURRENT_FUNCTION)...
-	../../../scripts/go-function-release.sh push contrib
+	@echo "Checking if $(CURRENT_FUNCTION) is a valid listed function..."
+	@if echo "$(FUNCTIONS)" | grep -qw "$(CURRENT_FUNCTION)"; then \
+		echo "Pushing image $(CURRENT_FUNCTION)..."; \
+		../../../scripts/go-function-release.sh push contrib; \
+	else \
+		echo "Error: $(CURRENT_FUNCTION) is not a valid listed function!"; \
+		exit 1; \
+	fi
 
 docs-generate:
 	$(GOBIN)/mdtogo $(CURRENT_FUNCTION) $(CURRENT_FUNCTION)/generated --license=none --strategy=cmdDocs

--- a/functions/go/Makefile
+++ b/functions/go/Makefile
@@ -154,8 +154,14 @@ func-build: func-verify
 	../../scripts/go-function-release.sh build curated
 
 func-push:
-	@echo Pushing image $(CURRENT_FUNCTION)...
-	../../scripts/go-function-release.sh push curated
+	@echo "Checking if $(CURRENT_FUNCTION) is a valid listed function..."
+	@if echo "$(FUNCTIONS)" | grep -qw "$(CURRENT_FUNCTION)"; then \
+		echo "Pushing image $(CURRENT_FUNCTION)..."; \
+		../../scripts/go-function-release.sh push curated; \
+	else \
+		echo "Error: $(CURRENT_FUNCTION) is not a valid listed function!"; \
+		exit 1; \
+	fi
 
 docs-generate:
 	$(GOBIN)/mdtogo $(CURRENT_FUNCTION) $(CURRENT_FUNCTION)/generated --license=none --strategy=cmdDocs


### PR DESCRIPTION
Update the existing gh action to trigger a tagged image push to ghcr when a new git tag is created during the Release process.